### PR TITLE
Fixes broken links in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 This is a collection of documents that outline Holiday Extras' culture and developer expectations.
 
 ## Contents
- * [General Javascript Best Practices](https://github.com/holidayextras/hx-culture/blob/master/general-javascript-best-practices.md)
- * [Clientside Javascript (Backbone) Best Practices](https://github.com/holidayextras/hx-culture/blob/master/clientside-javascript-best-practices.md)
- * [Clientside Javascript (jQuery) Best Practices](https://github.com/holidayextras/hx-culture/blob/master/clientside-jquery-best-practices.md)
- * [Coding Principles](https://github.com/holidayextras/hx-culture/blob/master/coding-principles.md)
- * [Organising code in backbone projects](https://github.com/holidayextras/hx-culture/blob/master/organising-code-backbone-projects.md)
- * [PR template](https://github.com/holidayextras/hx-culture/blob/master/pr-template.md)
- * [Holiday Extras Security Policy](https://github.com/holidayextras/hx-culture/blob/master/security-policy.md)
- * [Server Side Javascript Best Practices](https://github.com/holidayextras/hx-culture/blob/master/serverside-javascript-best-practices.md)
- * [Technical Planning Meetings](https://github.com/holidayextras/hx-culture/blob/master/technical-planning-meeting.md)
- * [Expedited Procedure](https://github.com/holidayextras/hx-culture/blob/master/expedited-procedure.md)
+ * [General Javascript Best Practices](https://github.com/holidayextras/culture/blob/master/general-javascript-best-practices.md)
+ * [Clientside Javascript (Backbone) Best Practices](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.md)
+ * [Clientside Javascript (jQuery) Best Practices](https://github.com/holidayextras/culture/blob/master/clientside-jquery-best-practices.md)
+ * [Coding Principles](https://github.com/holidayextras/culture/blob/master/coding-principles.md)
+ * [Organising code in backbone projects](https://github.com/holidayextras/culture/blob/master/organising-code-backbone-projects.md)
+ * [PR template](https://github.com/holidayextras/culture/blob/master/pr-template.md)
+ * [Holiday Extras Security Policy](https://github.com/holidayextras/culture/blob/master/security-policy.md)
+ * [Server Side Javascript Best Practices](https://github.com/holidayextras/culture/blob/master/serverside-javascript-best-practices.md)
+ * [Technical Planning Meetings](https://github.com/holidayextras/culture/blob/master/technical-planning-meeting.md)
+ * [Expedited Procedure](https://github.com/holidayextras/culture/blob/master/expedited-procedure.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 This is a collection of documents that outline Holiday Extras' culture and developer expectations.
 
 ## Contents
- * [General Javascript Best Practices](https://github.com/holidayextras/culture/blob/master/general-javascript-best-practices.md)
- * [Clientside Javascript (Backbone) Best Practices](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.md)
- * [Clientside Javascript (jQuery) Best Practices](https://github.com/holidayextras/culture/blob/master/clientside-jquery-best-practices.md)
- * [Coding Principles](https://github.com/holidayextras/culture/blob/master/coding-principles.md)
- * [Organising code in backbone projects](https://github.com/holidayextras/culture/blob/master/organising-code-backbone-projects.md)
- * [PR template](https://github.com/holidayextras/culture/blob/master/pr-template.md)
- * [Holiday Extras Security Policy](https://github.com/holidayextras/culture/blob/master/security-policy.md)
- * [Server Side Javascript Best Practices](https://github.com/holidayextras/culture/blob/master/serverside-javascript-best-practices.md)
- * [Technical Planning Meetings](https://github.com/holidayextras/culture/blob/master/technical-planning-meeting.md)
- * [Expedited Procedure](https://github.com/holidayextras/culture/blob/master/expedited-procedure.md)
+ * [General Javascript Best Practices](/general-javascript-best-practices.md)
+ * [Clientside Javascript (Backbone) Best Practices](/clientside-javascript-best-practices.md)
+ * [Clientside Javascript (jQuery) Best Practices](/clientside-jquery-best-practices.md)
+ * [Coding Principles](/coding-principles.md)
+ * [Organising code in backbone projects](/organising-code-backbone-projects.md)
+ * [PR template](/pr-template.md)
+ * [Holiday Extras Security Policy](/security-policy.md)
+ * [Server Side Javascript Best Practices](/serverside-javascript-best-practices.md)
+ * [Technical Planning Meetings](/technical-planning-meeting.md)
+ * [Expedited Procedure](/expedited-procedure.md)
 
 ## Contributing
 

--- a/organising-code-backbone-projects.md
+++ b/organising-code-backbone-projects.md
@@ -5,14 +5,14 @@
 We've extended the [Backbone library](http://backbonejs.org/)'s implementation of MVC with some of our own concepts - when adding new code it will tend to fit into one of these layers:
 
 - **Routers** are initialised by the application's entry point, and map the URL you visit (including when the URL changes without a page reload) to a method on a controller.
-- **Controllers** create and manage the high-level state of the application (which models, collections and views are currently in play). We use [dependency injection](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-use-dependency-injection) to propagate this state further down.
+- **Controllers** create and manage the high-level state of the application (which models, collections and views are currently in play). We use [dependency injection](/clientside-javascript-best-practices.mkd#do-use-dependency-injection) to propagate this state further down.
 - **Views** watch part of the user interface (usually a HTML document) for interactions, and communicate them back to models or controllers. They can render templates on the client, or augment HTML returned by the server.
 - **Templates** can generate strings of HTML given simple data as a context. They contain minimal logic, and are preferably written in [handlebars](http://handlebarsjs.com/).
-- **Presenters** decorate models with presentation logic. If it's too complicated for a template but not factual enough to be considered application state, [it probably belongs in a presenter](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-transform-data-for-presentation-using-presenters).
+- **Presenters** decorate models with presentation logic. If it's too complicated for a template but not factual enough to be considered application state, [it probably belongs in a presenter](/clientside-javascript-best-practices.mkd#do-transform-data-for-presentation-using-presenters).
 - **Models** represent business entities (like Basket or User or Lounge), and contain the current state of the application.
 - **Collections** are groups of related models, and functionality that applies to the group (eg filtering and sorting)
 - **Factories** map simple data into instances of things. If you've got data representing a Product, and that Product might be a Hotel or a Carpark or a Lounge, feed the data to the factory and it'll give you a ready-to-use instance of the relevant subclass back.
-- **Mixins/Concerns** are bundles of methods and properties that can be used to augment functionality into other objects. They can [help prevent](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-choose-between-using-composition-and-inheritance-carefully) the inheritance graph getting too complicated.
+- **Mixins/Concerns** are bundles of methods and properties that can be used to augment functionality into other objects. They can [help prevent](/clientside-javascript-best-practices.mkd#do-choose-between-using-composition-and-inheritance-carefully) the inheritance graph getting too complicated.
 
 ## Entity relationships
 
@@ -24,7 +24,7 @@ While any module in the application _can_ require any other, sticking to certain
 
 - Routers must require controllers.
 - Controllers can create models, collections and views.
-- Views _can_ create models and collections, but [it's preferable for controllers to](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-use-controllers-to-set-up-instances).
+- Views _can_ create models and collections, but [it's preferable for controllers to](/clientside-javascript-best-practices.mkd#do-use-controllers-to-set-up-instances).
 - Views can require templates.
 
 -----

--- a/organising-code-backbone-projects.md
+++ b/organising-code-backbone-projects.md
@@ -5,14 +5,14 @@
 We've extended the [Backbone library](http://backbonejs.org/)'s implementation of MVC with some of our own concepts - when adding new code it will tend to fit into one of these layers:
 
 - **Routers** are initialised by the application's entry point, and map the URL you visit (including when the URL changes without a page reload) to a method on a controller.
-- **Controllers** create and manage the high-level state of the application (which models, collections and views are currently in play). We use [dependency injection](https://github.com/holidayextras/hx-culture/blob/master/clientside-javascript-best-practices.mkd#do-use-dependency-injection) to propagate this state further down.
+- **Controllers** create and manage the high-level state of the application (which models, collections and views are currently in play). We use [dependency injection](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-use-dependency-injection) to propagate this state further down.
 - **Views** watch part of the user interface (usually a HTML document) for interactions, and communicate them back to models or controllers. They can render templates on the client, or augment HTML returned by the server.
 - **Templates** can generate strings of HTML given simple data as a context. They contain minimal logic, and are preferably written in [handlebars](http://handlebarsjs.com/).
-- **Presenters** decorate models with presentation logic. If it's too complicated for a template but not factual enough to be considered application state, [it probably belongs in a presenter](https://github.com/holidayextras/hx-culture/blob/master/clientside-javascript-best-practices.mkd#do-transform-data-for-presentation-using-presenters).
+- **Presenters** decorate models with presentation logic. If it's too complicated for a template but not factual enough to be considered application state, [it probably belongs in a presenter](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-transform-data-for-presentation-using-presenters).
 - **Models** represent business entities (like Basket or User or Lounge), and contain the current state of the application.
 - **Collections** are groups of related models, and functionality that applies to the group (eg filtering and sorting)
 - **Factories** map simple data into instances of things. If you've got data representing a Product, and that Product might be a Hotel or a Carpark or a Lounge, feed the data to the factory and it'll give you a ready-to-use instance of the relevant subclass back.
-- **Mixins/Concerns** are bundles of methods and properties that can be used to augment functionality into other objects. They can [help prevent](https://github.com/holidayextras/hx-culture/blob/master/clientside-javascript-best-practices.mkd#do-choose-between-using-composition-and-inheritance-carefully) the inheritance graph getting too complicated.
+- **Mixins/Concerns** are bundles of methods and properties that can be used to augment functionality into other objects. They can [help prevent](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-choose-between-using-composition-and-inheritance-carefully) the inheritance graph getting too complicated.
 
 ## Entity relationships
 
@@ -24,7 +24,7 @@ While any module in the application _can_ require any other, sticking to certain
 
 - Routers must require controllers.
 - Controllers can create models, collections and views.
-- Views _can_ create models and collections, but [it's preferable for controllers to](https://github.com/holidayextras/hx-culture/blob/master/clientside-javascript-best-practices.mkd#do-use-controllers-to-set-up-instances).
+- Views _can_ create models and collections, but [it's preferable for controllers to](https://github.com/holidayextras/culture/blob/master/clientside-javascript-best-practices.mkd#do-use-controllers-to-set-up-instances).
 - Views can require templates.
 
 -----


### PR DESCRIPTION
Seems the links in the read me have become broken when this was moved over, this just points them to the correct place.
