### PR TITLE
Removing UXUI and Blog post PR checkboxes

### DIFF
--- a/pr-template.md
+++ b/pr-template.md
@@ -12,7 +12,6 @@
 - [ ] I've checked there is appropriate unit, selenium and regression test coverage.
 - [ ] I've updated documentation with any changes to procedures.
 - [ ] I've tested this cross-browser/device for visual changes.
-- [ ] I've checked any significant visual changes with a member of the UX/UI pod.
 - [ ] I've checked this work against the requirements of the Jira.
 - [ ] I've manually checked this work against any dependent systems.
 - [ ] I've added and updated translations for all supported languages.
@@ -20,7 +19,6 @@
 - [ ] I've checked that there are no negative speed or performance impacts from my work.
 - [ ] I've added appropriate tracking.
 - [ ] I am ready for this to be code reviewed, merged and tested.
-- [ ] I've thought about writing a blog post about this.
 
 #### IP or Developer Review:
 - [ ] I agree with the assumptions made in the quality checklist.
@@ -49,4 +47,4 @@
 #### Software Tester review
 - [ ] I’ve run all the selenium tests locally and they pass.
 - [ ] I agree with the test coverage.
-- [ ] I've checked for Ruby changes and understand how to deploy if present. 
+- [ ] I've checked for Ruby changes and understand how to deploy if present.

--- a/pr-template.md
+++ b/pr-template.md
@@ -21,13 +21,11 @@
 - [ ] I am ready for this to be code reviewed, merged and tested.
 
 #### IP or Developer Review:
-- [ ] I agree with the assumptions made in the quality checklist.
 - [ ] I’ve witnessed the work behaving as expected.
 - [ ] I’ve run all the tests locally and they pass.
 - [ ] +1 from me!
 
 #### Software Engineer or Developer review:
-- [ ] I agree with the assumptions made in the quality checklist.
 - [ ] I’ve witnessed the work behaving as expected.
 - [ ] I’ve run all the tests locally and they pass.
 - [ ] I’ve checked for appropriate test coverage.
@@ -36,7 +34,6 @@
 - [ ] +1 from me!
 
 #### Software Engineer or project guru review:
-- [ ] I agree with the assumptions made in the quality checklist.
 - [ ] I’ve witnessed the work behaving as expected.
 - [ ] I’ve run all the tests locally and they pass.
 - [ ] I’ve checked for appropriate test coverage.


### PR DESCRIPTION
# What does this change?

It removes two sections of the PR template.
# Why?

They have been part of out PR template for many months and we haven't really seen any benefit of them bring there, both aren't really followed particularly well and are often just ticked blindly.
The issues there checkboxes relate to need to be tackled from a different angle.
