### PR TITLE
Update the PR template to streamline work

### DIFF
--- a/pr-template.md
+++ b/pr-template.md
@@ -5,7 +5,7 @@
 #### What gif best describes how you feel about this work?
 ---
 #### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
-- [ ] I have checked the contrbuting document and I'm happy for this to be reviewed.
+- [ ] I have checked the contributing document and I'm happy for this to be reviewed.
 
 #### Software Engineer or Developer review:
 - [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).

--- a/pr-template.md
+++ b/pr-template.md
@@ -1,46 +1,20 @@
-#### What does this PR do?
-#### What unit or integration tests does this PR have?
-#### What selenium tests does this PR have?
-#### How should a developer review this?
-#### How should this be manually tested?
-#### Any background context you want to provide?
-#### What are the relevant tickets?
-#### Screenshots (if appropriate)
+#### What does this PR do? (please provide any background)
+#### What tests does this PR have?
+#### How can this tested?
+#### Screenshots / Screencast
 #### What gif best describes how you feel about this work?
 ---
 #### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
-- [ ] I've checked there is appropriate unit, selenium and regression test coverage.
-- [ ] I've updated documentation with any changes to procedures.
-- [ ] I've tested this cross-browser/device for visual changes.
-- [ ] I've checked this work against the requirements of the Jira.
-- [ ] I've manually checked this work against any dependent systems.
-- [ ] I've added and updated translations for all supported languages.
-- [ ] I've informed those who need to know of any unforeseen impact of this work (database migrations, deployment procedure changes).
-- [ ] I've checked that there are no negative speed or performance impacts from my work.
-- [ ] I've added appropriate tracking.
-- [ ] I am ready for this to be code reviewed, merged and tested.
-
-#### IP or Developer Review:
-- [ ] I’ve witnessed the work behaving as expected.
-- [ ] I’ve run all the tests locally and they pass.
-- [ ] +1 from me!
+- [ ] I have checked the contrbuting document and I'm happy for this to be reviewed.
 
 #### Software Engineer or Developer review:
-- [ ] I’ve checked for appropriate test coverage.
+- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
 - [ ] I’ve checked for coding anti-patterns.
-- [ ] I've checked this work against the requirements of the Jira.
-- [ ] I’ve witnessed the work behaving as expected.
+- [ ] I’ve checked for appropriate test coverage.
 - [ ] I’ve run all the tests locally and they pass.
-- [ ] +1 from me!
 
 #### Software Engineer or project guru review:
-- [ ] I’ve checked for appropriate test coverage.
+- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
 - [ ] I’ve checked for coding anti-patterns.
-- [ ] I don’t believe this work introduces unnecessary technical debt.
-- [ ] I’ve witnessed the work behaving as expected.
+- [ ] I’ve checked for appropriate test coverage.
 - [ ] I’ve run all the tests locally and they pass.
-- [ ] +1 from me!
-
-#### Software Tester review
-- [ ] I’ve run all the selenium tests locally and they pass.
-- [ ] I agree with the test coverage.

--- a/pr-template.md
+++ b/pr-template.md
@@ -1,6 +1,6 @@
 #### What does this PR do? (please provide any background)
 #### What tests does this PR have?
-#### How can this tested?
+#### How can be this tested?
 #### Screenshots / Screencast
 #### What gif best describes how you feel about this work?
 ---


### PR DESCRIPTION
# What does this change?

Removes some of the vast process and tick box exercise around our PR process
Pushes for a CONTRIBUTING.md doc in all repos.
# Why?

Our deployment process is slow, slower than it should be. Some of this is down to out PR process.
We have stripped out the need for IP's to :+1: work (this shouldn't be a blocker for work to go live). However we swill still encourage IP's to pair program, pair code review and comment on code as much as possible.
PR's are as much about code quality as it is learning from and teaching others.
# Review

Please let me now your thoughts. If you have any questions or queries then please pop in and have a chat (rather than span GitHub).
