### PR TITLE
Change assert to sinon.assert

### DIFF
--- a/testing-standard.md
+++ b/testing-standard.md
@@ -39,7 +39,7 @@ sinon.stub(someModule, '_add').returns(expectedResult);             // stubbing 
 var result = someModule._proxy(first, second);
 
 assert.equal(result, expectedResult);                               // assert the return value
-assert.ok(someModule._add.calledWith(first, second));               // assert the stub was invoked as expected
+sinon.assert.calledWith(someModule._add, first, second);            // assert the stub was invoked as expected
 someModule._add.restore();                                          // restore the stub
 ```
 


### PR DESCRIPTION
Using `sinon.assert` to test sinon functions provides much better error messages if that assert ever fails.

```
> assert.ok(someModule._add.calledWith('first', 'third'));
AssertionError: false == true
```

```
> sinon.assert.calledWith(someModule._add, 'first', 'third');
AssertError: expected add to be called with arguments first, third
```
