### PR TITLE
Recommend master branch protection for GitHub host repositories

### DIFF
--- a/git-best-practices.md
+++ b/git-best-practices.md
@@ -3,16 +3,16 @@
 
 ## Repositories
 
-### Master branch protection
+### Branch protection
 
-Repositories hosted on GitHub **should** have their **master** (and **staging**
-when applicable) branch [protected]
+Repositories hosted on GitHub **should** have their **non-feature**
+(e.g. **master**, **staging**, **edge**, ...) branches [protected]
 (https://help.github.com/articles/about-protected-branches/). This will prevent
-the branch from accidentally:
+the branches from accidentally:
 
 * Being force pushed
 * Being deleted
-* [Optional] Having changes merged into it until required status checks pass
+* [Optional] Having changes merged into them until required status checks pass
 
 ## Branching
 

--- a/git-best-practices.md
+++ b/git-best-practices.md
@@ -5,13 +5,14 @@
 
 ### Master branch protection
 
-Repositories hosted on GitHub **should** have their **master** branch
-[protected] (https://help.github.com/articles/about-protected-branches/). This
-will prevent the **master** branch from accidentally:
+Repositories hosted on GitHub **should** have their **master** (and **staging**
+when applicable) branch [protected]
+(https://help.github.com/articles/about-protected-branches/). This will prevent
+the branch from accidentally:
 
 * Being force pushed
 * Being deleted
-* Having changes merged into it until required status checks pass
+* [Optional] Having changes merged into it until required status checks pass
 
 ## Branching
 

--- a/git-best-practices.md
+++ b/git-best-practices.md
@@ -1,6 +1,18 @@
 # Git Best Practices
 
 
+## Repositories
+
+### Master branch protection
+
+Repositories hosted on GitHub **should** have their **master** branch
+[protected] (https://help.github.com/articles/about-protected-branches/). This
+will prevent the **master** branch from accidentally:
+
+* Being force pushed
+* Being deleted
+* Having changes merged into it until required status checks pass
+
 ## Branching
 
 ### The master or default branch


### PR DESCRIPTION
GitHub now supports server side protection of branches. Our recommended default setting is to enable this for all our repositories hosted on GitHub.
- [x] +1
- [x] +2
