### PR TITLE
Block merges until CI passes is recommended

### DIFF
--- a/git-best-practices.md
+++ b/git-best-practices.md
@@ -12,7 +12,7 @@ the branches from accidentally:
 
 * Being force pushed
 * Being deleted
-* [Optional] Having changes merged into them until required status checks pass
+* Having changes merged into them until required status checks pass
 
 ## Branching
 


### PR DESCRIPTION
Require status checks to pass before allowing branches to be merged is the setting **recommended** by our technical committee. Update the wording accordingly.
- [x] :+1: 
- [ ] :+1: :+1: 
