### PR TITLE
Prefer global `'use strict';' at the module level.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -97,7 +97,7 @@
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
-    "strict": 2,
+    "strict": [2, "global"],
     "valid-jsdoc": 2,
     "yoda": [2, "never"]
   }


### PR DESCRIPTION
From version 1.0 ESLint has clear `function` and `global` (defaulting to `function`) settings for the `strict` rule. For NodeJS projects the `global` setting makes the most sense, and now that we've switched to using Browserify for front-end projects, `global` should do the right thing for those also, while avoiding the verbosity of one `'use strict';` directive per function.
