### PR TITLE
Reviewers for group tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,6 @@ The PR template in this repository is targeted at code changes, so we'd suggest 
 
 Pull requests to this repository are open to input / discussion / agreement by all, there is no requirement of approval by a fixed number of people with specific roles as in the template for code changes.
 
-If an update or addition refers to a process or technology which is in use or to be implemented by the group, please make sure that the PR has reviewers from both sides and to notify a member of the group tech to discuss appropriate handling of the change.
+If an update or addition refers to a process or technology which is, or is to be, implemented by the group, please ensure that the PR includes applicable reviewers from of each part of the group and notify a member of the group tech panel to discuss appropriate handling of the change.
 
 If a PR has been open for several days with no unresolved comments, or it's otherwise clear from comments many people have had the chance to read and agree, we should consider it good to merge; further changes can always be raised through additional followup PRs.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,8 @@ The PR template in this repository is targeted at code changes, so we'd suggest 
 # Why?
 ```
 
-Pull requests to this repository are open to input / discussion / agreement by all, there is no requirement of approval by a fixed number of people with specific roles as in the template for code changes. If a PR has been open for several days with no unresolved comments, or it's otherwise clear from comments many people have had the chance to read and agree, we should consider it good to merge; further changes can always be raised through additional followup PRs.
+Pull requests to this repository are open to input / discussion / agreement by all, there is no requirement of approval by a fixed number of people with specific roles as in the template for code changes.
+
+If an update or addition refers to a process or technology which is in use or to be implemented by the group, please make sure that the PR has reviewers from both sides and to notify a member of the group tech to discuss appropriate handling of the change.
+
+If a PR has been open for several days with no unresolved comments, or it's otherwise clear from comments many people have had the chance to read and agree, we should consider it good to merge; further changes can always be raised through additional followup PRs.


### PR DESCRIPTION
# What does this change?

Added a note to mention how we should be handling reviewers of changes to group tech or process.
# Why?

We would like everyone to be able to make improvements to group tech, but both sides of the road must be involved in reviewing these changes to give them the best chance of being adopted.
