### PR TITLE
Correct value for `jsx-quotes` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,7 +30,7 @@
     "handle-callback-err": [2, "^(err|error)$"],
     "indent": [2, 2],
     "linebreak-style": [2, "unix"],
-    "jsx-quotes": [2, "double", "avoid-escape"],
+    "jsx-quotes": [2, "prefer-double"],
     "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
     "new-cap": 2,
     "new-parens": 2,


### PR DESCRIPTION
Apologies, I was a bit distracted and didn't update the value from the old `react/jsx-quotes` rule to the one expected by the new `jsx-quotes` rules. This fixes the issue and (finally) correctly updates the rule set for the forthcoming `make-up` ESLint 1.8.0 update PR.
- [x] :+1: 
- [x] :shipit: 
