### PR TITLE
pr-template-ip added IP slot in template

### DIFF
--- a/pr-template.md
+++ b/pr-template.md
@@ -7,6 +7,12 @@
 #### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
+#### IP review (optional):
+- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
+- [ ] I’ve checked for coding anti-patterns.
+- [ ] I’ve checked for appropriate test coverage.
+- [ ] I’ve checked all the tests are passing.
+
 #### Software Engineer or Developer review:
 - [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
 - [ ] I’ve checked for coding anti-patterns.


### PR DESCRIPTION
# What does this change?

Added IP slot in the Pr-template
# Why?

We would like to allow IP's to be have a slot so that they'll be able to review PR's. This is an optional field which means if you don't get an IP to review the PR it won't block you from pushing your work forward. 
