### PR TITLE
Slim down the PR template

### DIFF
--- a/pr-template.md
+++ b/pr-template.md
@@ -1,20 +1,30 @@
 #### What does this PR do? (please provide any background)
+
+
 #### What tests does this PR have?
+
+
 #### How can this be tested?
+
+
 #### Screenshots / Screencast
+
+
 #### What gif best describes how you feel about this work?
+![](url)
+
 ---
-#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
+
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
-#### Software Engineer or Developer review:
-- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
-- [ ] I’ve checked for coding anti-patterns.
-- [ ] I’ve checked for appropriate test coverage.
-- [ ] I’ve checked all the tests are passing.
+#### Reviewers (edit comment to add your github username and then +1)
 
-#### Software Engineer or project guru review:
-- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
-- [ ] I’ve checked for coding anti-patterns.
-- [ ] I’ve checked for appropriate test coverage.
-- [ ] I’ve checked all the tests are passing.
+[ ] IP (optional)
+[ ] Dev
+[ ] SE/Guru
+
+By adding a +1 you are confirming you have...
+- Witnessed the work behaving as expected (this could be on the authors machine or screencast).
+- Checked for coding anti-patterns.
+- Checked for appropriate test coverage.
+- Checked all the tests are passing.

--- a/pr-template.md
+++ b/pr-template.md
@@ -29,7 +29,7 @@
 - [ ] :+1:
 
 By adding a +1 you are confirming you have...
-- Witnessed the work behaving as expected (this could be on the authors machine or screencast).
+- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
 - Checked for coding anti-patterns.
 - Checked for appropriate test coverage.
 - Checked all the tests are passing.

--- a/pr-template.md
+++ b/pr-template.md
@@ -17,15 +17,15 @@
 
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
-#### Reviewers
+#### Reviewers (replace _available with your username)
 
-IP _(optional)_
+IP: _available_
 - [ ] :+1:
 
-Dev
+Dev: _available_
 - [ ] :+1:
 
-SE/Guru
+SE/Guru: _available_
 - [ ] :+1:
 
 By adding a +1 you are confirming you have...

--- a/pr-template.md
+++ b/pr-template.md
@@ -17,11 +17,16 @@
 
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
-#### Reviewers (edit comment to add your github username and then +1)
+#### Reviewers
 
-[ ] IP (optional)
-[ ] Dev
-[ ] SE/Guru
+IP _(optional)_
+- [ ] :+1:
+
+Dev
+- [ ] :+1:
+
+SE/Guru
+- [ ] :+1:
 
 By adding a +1 you are confirming you have...
 - Witnessed the work behaving as expected (this could be on the authors machine or screencast).

--- a/pr-template.md
+++ b/pr-template.md
@@ -19,13 +19,13 @@
 
 #### Reviewers
 
-**IP** _(optional)_
+**Review 1**
 - [ ] :+1:
 
-**Dev**
+**Review 2** \*
 - [ ] :+1:
 
-**SE/Guru**
+**Review 3** _(optional)_
 - [ ] :+1:
 
 By adding a +1 you are confirming you have...
@@ -33,3 +33,5 @@ By adding a +1 you are confirming you have...
 - Checked for coding anti-patterns.
 - Checked for appropriate test coverage.
 - Checked all the tests are passing.
+
+\*  for HX this review must be completed by an SE, SA or Project Guru

--- a/pr-template.md
+++ b/pr-template.md
@@ -17,15 +17,15 @@
 
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
-#### Reviewers (replace _available_ with your username)
+#### Reviewers
 
-**IP:** _available_
+**IP** _(optional)_
 - [ ] :+1:
 
-**Dev:** _available_
+**Dev**
 - [ ] :+1:
 
-**SE/Guru:** _available_
+**SE/Guru**
 - [ ] :+1:
 
 By adding a +1 you are confirming you have...

--- a/pr-template.md
+++ b/pr-template.md
@@ -17,15 +17,15 @@
 
 - [ ] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.
 
-#### Reviewers (replace _available with your username)
+#### Reviewers (replace _available_ with your username)
 
-IP: _available_
+**IP:** _available_
 - [ ] :+1:
 
-Dev: _available_
+**Dev:** _available_
 - [ ] :+1:
 
-SE/Guru: _available_
+**SE/Guru:** _available_
 - [ ] :+1:
 
 By adding a +1 you are confirming you have...


### PR DESCRIPTION
Following on from the discussion around IPs giving an optional review I'd like to propose an update to the pr template.
### What's changed
- Added whitespace to save time
- Removed wordy dev checklist heading
- Turned checkboxes in to a list
- Added 3 tickboxes to indicate +1
- Removed job titles to make it usable by the entire group
