### PR TITLE
Moved docs from server to general

### DIFF
--- a/general-javascript-best-practices.md
+++ b/general-javascript-best-practices.md
@@ -145,3 +145,28 @@ var name = "oli";
 var list = [ 1, 4, 5, 7, 9 ];
 doStuff(name, list);
 ```
+
+## Module Template
+
+All modules should follow this order:
+
+1. define a local object and export it
+2. `require()` in any dependencies
+3. (all the logic goes here)
+
+For example:
+```javascript
+// define a local object and export it
+var ourModuleName = module.exports = { };
+
+// Next, require any dependencies:
+var _ = require('underscore');
+var moment = require('moment');
+var async = require('async');
+
+// Now attach all functionality to our local object:
+ourModuleName.somePublicFunction = function() { };
+ourModuleName._somePrivateFunction = function() { };
+```
+
+In the above example its easy to identify a module's dependencies and the module's exports without having to scroll anywhere. It also sets the scene to attach any public and private functions to the exported object to enable testing and it means all functions can be pushed up against the start of the line with no unnecessary indentation.

--- a/serverside-javascript-best-practices.md
+++ b/serverside-javascript-best-practices.md
@@ -57,40 +57,6 @@ Any piece of logically distinct code that we share between other projects should
   * version number
   * dependencies
 
-
-
-
-
-
-## Module Template
-
-All modules should follow this order:
-
-1. define a local object and export it
-2. `require()` in any dependencies
-3. (all the logic goes here)
-
-For example:
-```javascript
-// define a local object and export it
-var ourModuleName = module.exports = { };
-
-// Next, require any dependencies:
-var _ = require('underscore');
-var moment = require('moment');
-var async = require('async');
-
-// Now attach all functionality to our local object:
-ourModuleName.somePublicFunction = function() { };
-ourModuleName._somePrivateFunction = function() { };
-```
-
-In the above example its easy to identify a module's dependencies and the module's exports without having to scroll anywhere. It also sets the scene to attach any public and private functions to the exported object to enable testing and it means all functions can be pushed up against the start of the line with no unnecessary indentation.
-
-
-
-
-
 ## Promises or Callbacks?
 
 Provided the orchestration of asynchronous actions are decoupled from the code that provides functionality, both conventions are acceptable. For example, both of the following examples are great:


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

I've just moved the server side module best practice to the the general JS doc. It has not been changed at all.

Reviews should review this as when we write commonjs on the client the modules should follow the same format as when we write them on the server.

_HX_ 
- [ ] :+1:

_Short breaks_
- [ ] :+1:
