### PR TITLE
Update linting guidelines for using chai

### DIFF
--- a/testing-standard.md
+++ b/testing-standard.md
@@ -30,10 +30,13 @@ expect(myStub).to.have.been.calledWith('foo');
 
 
 ### Linting Issues
-You may occasionally encounter a slight issue here with our linting, specifically our linting complaining about unused expressions in the tests due to Chai's syntax. There are a couple of viable workarounds for this:
+You may occasionally encounter a slight issue here with our linting, specifically our linting complaining about unused expressions in the tests due to Chai's syntax. The solution to this is to use [dirty-chai](https://www.npmjs.com/package/dirty-chai) or [chai-lint](https://www.npmjs.com/package/chai-lint) to provide functions that replace the property getters provided by Chai. This allows us to use syntax such as:
 
- * Use packages like [dirty-chai](https://www.npmjs.com/package/dirty-chai) or [chai-lint](https://www.npmjs.com/package/chai-lint) to provide functions that replace the property getters provided by Chai **(recommended)**.
- * Turn off `no-unused-expression` linting rule for your tests.
+```javascript
+
+expect(myStub).to.have.been.called();
+```
+
 
 ## 1.2 Good Test Folders
 When addind new tests to projects, test files should sit in a folder hierarchy that mimics the hierarchy fo the source code. The test files themselves should be named similarly to the source files, but with `test` at the beginning of the file name. For example, if we have a source file `src/views/checkoutView.js` we should have a test file `test/unit/views/checkoutView.js` or similar. This makes finding tests an easy and logical process.

--- a/testing-standard.md
+++ b/testing-standard.md
@@ -30,7 +30,7 @@ expect(myStub).to.have.been.calledWith('foo');
 
 
 ### Linting Issues
-You may occasionally encounter a slight issue here with our linting, specifically our linting complaining about unused expressions in the tests due to Chai's syntax. The solution to this is to use [dirty-chai](https://www.npmjs.com/package/dirty-chai) or [chai-lint](https://www.npmjs.com/package/chai-lint) to provide functions that replace the property getters provided by Chai. This allows us to use syntax such as:
+You may occasionally encounter a slight issue here with our linting, specifically our linting complaining about unused expressions in the tests due to Chai's syntax. The solution to this is to use [dirty-chai](https://www.npmjs.com/package/dirty-chai) to provide functions that replace the property getters provided by Chai. This allows us to use syntax such as:
 
 ```javascript
 


### PR DESCRIPTION
We've been using `dirty-chai` to prevent linting errors when using chai for our automated tests. This is now in place in trip app and hapi and means that we don't have to add a comment to the top of our files to disable linting. Updated the testing-standard to reflect this.
- [x] :+1:
- [x] :+1::+1:
