### PR TITLE
CI best practices - promoting artifacts

### DIFF
--- a/ci-best-practices.md
+++ b/ci-best-practices.md
@@ -63,6 +63,7 @@ Points to note:
 
 ### Do's
 
+* Do create an artifact and promote it toward production (rather than eg re-building the project 3x on integration, staging & production)
 * Do cache any dependency directories (such as `node_modules`).
 * Do fail the CI process as soon as one task fails.
 * Do run the quickest and / or most likely to fail tasks first, to enable a broken build to end quicker.


### PR DESCRIPTION
Add a note recommending building as few times as possible. Build once, redeploy what you already built to other environments in later steps.

This will speed up the process of getting code to production, and reduce the risk of a non-idempotent build introducing production issues.
- [x] 1
- [ ] 2
