### PR TITLE
added another prefered lib

### DIFF
--- a/general-javascript-best-practices.md
+++ b/general-javascript-best-practices.md
@@ -149,6 +149,10 @@ Use instead of underscore, due to correct semantic versioning, better performanc
 
 Please only require the methods you need rather than the whole library in order to keep build sizes at a minimum.
 
+### grunt-shell
+
+Use instead of grunt-exec, due to a configurable max output buffer size option. Required if running a command with a lot of output.
+
 ## What antipatterns could I run into with my newfound ES6 power?
 
 ### Auto Destructuring


### PR DESCRIPTION
# What does this change?

I've added a note to prefer `grunt-shell` over `grunt-exec`.
# Why?

After some head banging it seems that `grunt-exec` has a fixed output buffer size, so will fail with an unhelpful error message even if the command it runs succeeds, this is a problem when running on CI.

There is already an open issue on the problem: https://github.com/jharding/grunt-exec/issues/67
- [x] Distribution
- [x] Shortbreaks
