### PR TITLE
Add jquery exceptions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -54,7 +54,7 @@
     "linebreak-style": [2, "unix"],
     "jsx-quotes": [2, "prefer-double"],
     "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
-    "new-cap": 2,
+    "new-cap": [2, {"capIsNewExceptions": ["jQuery.Event", "$.Event", "$.Deferred"]}],
     "new-parens": 2,
     "no-alert": 2,
     "no-array-constructor": 2,


### PR DESCRIPTION
# What does this change?

This work adds the rule to our global ruleset to allow some jquery exceptions that do not follow the naming convention we would prefer.
# Why?

We had a project specific rule in one of our private projects that was not using our makeup utility.

**Review 1**
- [x] :+1:

**Review 2**
- [x] :+1:
