### PR TITLE
eslint arrow spacing before & after

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,7 @@
     "experimentalObjectRestSpread": false
   },
   "rules": {
+    "arrow-spacing": [2, { "before": true, "after": true }],
     "block-scoped-var": 2,
     "brace-style": [2, "1tbs"],
     "camelcase": [2, {"properties": "never"}],


### PR DESCRIPTION
Force spacing around arrow functions in our `.eslintrc`, see [the eslint docs](http://eslint.org/docs/rules/arrow-spacing) for more info

``` javascript
// good
() => {

// bad
()=>{
```
- [x] :+1: 
- [x] :+1: 
- [x] :+1: 
