### PR TITLE
Enable global sinon sandboxes within eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,7 @@
 {
   "globals": {
+    "sinon": true,
+    "sandbox": true
   },
   "env": {
     "node": true,


### PR DESCRIPTION
We're using a global sinon sandbox in trip-planner. This let's us lint that properly.
- [x] :+1: 
- [x] :+1: 
- [x] :+1: 
