### PR TITLE
Update .eslintrc file to be compatible with eslint 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,36 +9,18 @@
     "amd": true,
     "browser": true,
     "jasmine": true,
-    "jquery": true
+    "jquery": true,
+    "es6": true
   },
   "plugins": [
     "mocha",
     "react"
   ],
-  "ecmaFeatures": {
-    "jsx": true,
-    "arrowFunctions": true,
-    "binaryLiterals": false,
-    "blockBindings": true,
-    "classes": false,
-    "defaultParams": false,
-    "destructuring": true,
-    "forOf": false,
-    "generators": false,
-    "modules": false,
-    "objectLiteralComputedProperties": false,
-    "objectLiteralDuplicateProperties": false,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "octalLiterals": false,
-    "regexUFlag": false,
-    "regexYFlag": false,
-    "restParams": true,
-    "spread": true,
-    "superInFunctions": false,
-    "templateStrings": true,
-    "unicodeCodePointEscapes": false,
-    "experimentalObjectRestSpread": false
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "jsx": true
+    }
   },
   "rules": {
     "arrow-spacing": [2, { "before": true, "after": true }],
@@ -58,6 +40,13 @@
     "linebreak-style": [2, "unix"],
     "jsx-quotes": [2, "prefer-double"],
     "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
+    "keyword-spacing": [2, {
+      "before": true,
+      "after": true,
+      "overrides": {
+        "function": { "before": false }
+      }
+    }],
     "mocha/no-exclusive-tests": 2,
     "new-cap": [2, {"capIsNewExceptions": ["jQuery.Event", "$.Event", "$.Deferred"]}],
     "new-parens": 2,
@@ -76,7 +65,6 @@
     "no-else-return": 2,
     "no-empty": 2,
     "no-empty-character-class": 2,
-    "no-empty-label": 2,
     "no-eval": 2,
     "no-ex-assign": 2,
     "no-extend-native": 2,
@@ -92,7 +80,7 @@
     "no-irregular-whitespace": 2,
     "no-iterator": 2,
     "no-label-var": 2,
-    "no-labels": 2,
+    "no-labels": [2, { "allowLoop": true, "allowSwitch": true }],
     "no-lone-blocks": 2,
     "no-loop-func": 2,
     "no-mixed-requires": [2, { "grouping": false }],
@@ -151,11 +139,7 @@
     "react/wrap-multilines": 2,
     "semi": [2, "always"],
     "semi-spacing": [2, {"before": false, "after": true}],
-    "space-after-keywords": [2, "always"],
-    "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, "never"],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "strict": [2, "global"],
     "use-isnan": 2,


### PR DESCRIPTION
Updates .eslintrc file to be eslint 2.x compatible. 
This removes the individual ES6 feature flags. I can't see a way of disabling certain parts anymore. It makes sense, you can't disable individual parts of ES5. It's important to note that modules are still disabled with this config, you have to explicitly turn these on: http://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options
- [x] :+1: 
- [x] :+1: 
- [x] :+1: 
