### PR TITLE
adding experimentalObjectRestSpread rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   "parserOptions": {
     "ecmaVersion": 6,
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
+      "experimentalObjectRestSpread": true
     }
   },
   "rules": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

adds experimentalObjectRestSpread to linting rules.
This allows the following:

```
const {a, ...other} = { a: 'A', b: 'B', c: 'C' }
console.log(a) // A
console.log(other) // {b: 'B', c: 'C'}
```
#### What tests does this PR have?

N/A
#### How can this be tested?

N/A
#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![](url)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** *
- [ ] :+1:

**Review 3** _(optional)_
- [ ] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru
