### PR TITLE
Add `callback-return` to ESLint ruleset

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
   "rules": {
     "block-scoped-var": 2,
     "brace-style": [2, "1tbs"],
+    "callback-return": 2,
     "camelcase": [2, {"properties": "never"}],
     "comma-dangle": [2, "never"],
     "comma-spacing": 2,


### PR DESCRIPTION
This PR adds the [`callback-return`](http://eslint.org/docs/rules/callback-return) rule to the ESLint ruleset.

This will help avoid one of the frequent reason for crashes that have been happening frequently on HAPI.

:warning: this rule can have _false positives_ and _false negatives_ (please read the [known limitations](http://eslint.org/docs/rules/callback-return#known-limitations) for details) but in general the benefits should heavily outweigh the minor annoyance of dealing with these. We have run `make-up` with this rule enabled on the HAPI and have verified that it would have avoided deploying to production the PR that produced the crashes today.
#### What gif best describes how you feel about this work?

![](http://tclhost.com/vgTJ7Zi.gif)

---
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.
#### Reviewers

**Airports**
- [x] :+1:

**Short Breaks**
- [x] :+1:
