### PR TITLE
adding instructions for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is a collection of documents that outline Holiday Extras' culture and devel
  * [Definition of Ready and Done](definition-of-ready-and-done.md)
  * [Contributing to projects](CONTRIBUTIUNG.md)
  * [Pair programming] (pairing.md)
+ * [Translations](translations.md)
 
 ### Other
 

--- a/translations.md
+++ b/translations.md
@@ -1,0 +1,19 @@
+# Translations
+
+Several of our systems are multi-lingual and the functionality for our customers depends upon this fact. While we do not currently support what we could call fully multi-lingual, international and localised applications we should work towards this being an eventuality.
+
+Where internationalisation is available you should endeavour to always provide translations for all text rendered to the customer in each available language. This includes error messages etc which may not be rendered directly within templates.
+
+## What makes a good translation?
+It is recommended that translations be based around entire sentences or phrases and do not include any markup. This is to prevent cases where word order, sentence structure and changing genders, ordinals etc. could create incorrect translations.
+
+## Where can I get translations?
+To get translations for text you can raise a ticket on the [European Translations Kanban board](https://holidayextras.jira.com/secure/RapidBoard.jspa?rapidView=292&projectKey=DEM). When doing so please specify which languages you require the text to be translated into.
+
+The languages supported currently are German (DE), Dutch (NL), French (FR), Italian (IT), Portuguese (PT) and Spanish (ES).
+
+It is also important that you provide the context in which you will be using the text as this can lead to variations in the resulting translation.
+
+For example: 'Please translate "book" into German.' could get you back "das Buch" (noun) or "buchen" (verb).
+
+Also, however tempting, Google Translate is not an acceptable resource for translations.


### PR DESCRIPTION
# What does this change?

I'm adding some instructions on where to get translations from for supported apps and some guidelines on best practices for the translations.
# Why?

Because we all need to know how to get translations and I keep forgetting.
- [x] +1
- [x] +2
