### PR TITLE
`.eslintrc`: no multiple empty lines

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -88,6 +88,7 @@
     "no-mixed-spaces-and-tabs": [2, false],
     "no-multi-spaces": 2,
     "no-multi-str": 2,
+    "no-multiple-empty-lines": [2, { "max": 2, "maxEOF": 1 }],
     "no-native-reassign": 2,
     "no-negated-in-lhs": 2,
     "no-nested-ternary": 2,


### PR DESCRIPTION
 Add `no-multiple-empty-lines` to our `.eslintrc`.

This rule enforces a maximum of 2 empty lines and a maximum of one at the end of file (catching some files with multiple empty lines at the end we have floating around). This is purely cosmetic but nice to have and can be automatically fixed.
