### PR TITLE
Restore block spacing rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -141,6 +141,8 @@
     "react/wrap-multilines": 2,
     "semi": [2, "always"],
     "semi-spacing": [2, {"before": false, "after": true}],
+    "space-before-blocks": [2, "always"],
+    "space-before-function-paren": [2, "never"],
     "space-infix-ops": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "strict": [2, "global"],


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This work puts two missing rules back, these rules were removed in error when eslint was upgraded.

See this commit: https://github.com/holidayextras/culture/pull/105/commits/6847b0b871c747f8bfadcb05ce003ac8bd0e44eb for when the problem was introduced.
#### What tests does this PR have?

N/A
#### How can this be tested?

The following code currently passes on the (broken) current linting rules.

``` javascript
'use strict';

var a = function(){
  return 0;
};

var b = function (){
  return 0;
};

var c = function() {
  return 1;
};

a();
b();
c();
```

With this change it will now fail, as only the third example is what we expect.
#### Any tech debt?
#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/18291461/af868090-747f-11e6-92cf-7516171d66bc.gif)
- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

---

**Reviewer**
- [x] :+1:
- [x] I don't think this PR needs any additional reviewers

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
