### PR TITLE
Added a readme template for our repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This is a collection of documents that outline Holiday Extras' culture and devel
 
  * [Pest Control Process](pest-control-process.md)
  * [PR Template](pr-template.md)
+ * [Readme Template](readme-template.md)
  * [Expedited Procedure](expedited-procedure.md)
  * [General Meetings](general-meetings.md)
  * [Technical Planning Meetings](technical-planning-meeting.md)

--- a/readme-template.md
+++ b/readme-template.md
@@ -1,106 +1,93 @@
 # Repo Title
 
-<!-- Not all of these are essential but keep this in mind for the repo you are using -->
-![Build badge]() ![Test Coverage]() ![npm package]()
+<!-- Not all of these are essential but keep this in mind for the repo you are using
+![Build badge]() ![Test Coverage]() ![npm package]() -->
 
 <!--Short sentence on what the repo does-->
 
 <!-- possibly list experts in this repo for who to go to when encountering a problem-->
 
 ##Contents
-* [Further Documentation](#documentation)
-* [System Overview](#overview)
+* [Further Documentation](#further-documentation)
+* [System Overview](#system-overview)
 * [Installation](#installation)
-* [Running Locally](#running)
+* [Running Locally](#running-locally)
 * [Testing](#testing)
 	* [Automated Testing](#automated)
 	* [Manual testing](#manual)
 * [Script cheat sheet](#cheat-sheet)
 * [Built With](#built-with)
-* [Deploying](#deploy)
 * [Linting](#linting)
-* [Contributing Rules](#rules)
-* [Common Questions](#faq)
+* [Deploying](#deploying)
+* [Contributing Rules](#contributing-rules)
+* [Common Questions](#common-questions)
 
-<a name="documentation"></a>
 ## Further Documentation
 
+<!-- Examples of some documentation to link from the readme -->
 * **[System Roadmap]()**
 * **[Regression Testing Checklist]()**
 * **[Change Log]()**
 
 Include any other relevant documentation in this section.
 
-<a name="overview"></a>
 ## System Overview
 
 * More in-depth overview of the system, what this is trying to accomplish and how it achieves its goal.
 * Keep it concise, write this section like the first paragraph of a blog post, what is the point of this repo?
+* Perhaps label some of the core tech used in the repo and link to the external websites/documentation
 
-<a name="installation"></a>
 ## Installation
 
-* Recordit of installation setup for new users
 * Step-by-step guide on installation
 
-<a name="running"></a>
 ## Running Locally
 
-* Recordit of setting up the app for running locally
 * Step-by-step guide of setting up locally
 
-<a name="testing"></a>
-## Testing
-
-* What CI do the test run on?
-* What testing framework is used?
-
-<a name="cheat-sheet"></a>
 ## Script Cheat Sheet
 
 * List scripts used in the repo and a description of what they do
 * Example: `npm run build` := Generates `dist` folder with changes made in `lib`
 
-<a name="testing"></a>
 ## Testing
 
-<a name="automated"></a>
+* What CI do the test run on?
+* What testing framework is used?
+* How are the tests structured in this repo? Is there a strict writing style to follow?
+
 ### Automated Testing
 
-* Step-by-step to run unit/selenium tests
+* Step-by-step to run all automated testing.
+* What are some of the commands I need to know when running test in my local environment?
+* Any tips on running singular tests or groups of tests at once in this repo?
 
-<a name="manual"></a>
 ### Manual Testing
 
 * Link to external regression checklist document
+* If anything particular is setup for this repo, describe how you would manually test a feature branch before going to production
 
-<a name="built-with"></a>
 ## Built With
 
 * What frameworks are used? Links to framework API docs.
 * Essential node modules used, links to documentation/repo.
 
-<a name="deploy"></a>
-## Deploying
-
-* How do deploys work for new pull requests?
-* What is the process from a feature branch to production?
-
-<!-- Optional on README but should be linked externally if not -->
-<a name="linting"></a>
 ## Linting
 
 * How to I lint specific file types?
 * Do these run via git hooks
 * Link to linting rules
 
-<a name="rules"></a>
+## Deploying
+
+* How do deploys work for new pull requests?]
+* Steps on how to get a feature branch merged and deployed into production environment
+
 ## Contributing Rules
 
 * Link to HX-culture documentation on contribution
 * Any specific rules for this repo?
 
-<a name="faq"></a>
 ## Common Questions
 
 * Frequently asked questions that will help engineers

--- a/readme-template.md
+++ b/readme-template.md
@@ -5,8 +5,6 @@
 
 <!--Short sentence on what the repo does-->
 
-<!-- possibly list experts in this repo for who to go to when encountering a problem-->
-
 ##Contents
 * [Further Documentation](#further-documentation)
 * [System Overview](#system-overview)
@@ -91,4 +89,4 @@ Include any other relevant documentation in this section.
 ## Common Questions
 
 * Frequently asked questions that will help engineers
-* Link to repo experts if not listed
+* Link/State which stretch/guild would be best to chat with to answer questions not listed here

--- a/readme-template.md
+++ b/readme-template.md
@@ -51,6 +51,7 @@ Include any other relevant documentation in this section.
 ## Testing
 
 * What CI do the test run on?
+  * Link to CI website/status page
 * What testing framework is used?
 * How are the tests structured in this repo? Is there a strict writing style to follow?
 
@@ -78,7 +79,7 @@ Include any other relevant documentation in this section.
 
 ## Deploying
 
-* How do deploys work for new pull requests?]
+* How do deploys work for new pull requests?
 * Steps on how to get a feature branch merged and deployed into production environment
 
 ## Contributing Rules

--- a/readme-template.md
+++ b/readme-template.md
@@ -1,0 +1,107 @@
+# Repo Title
+
+<!-- Not all of these are essential but keep this in mind for the repo you are using -->
+![Build badge]() ![Test Coverage]() ![npm package]()
+
+<!--Short sentence on what the repo does-->
+
+<!-- possibly list experts in this repo for who to go to when encountering a problem-->
+
+##Contents
+* [Further Documentation](#documentation)
+* [System Overview](#overview)
+* [Installation](#installation)
+* [Running Locally](#running)
+* [Testing](#testing)
+	* [Automated Testing](#automated)
+	* [Manual testing](#manual)
+* [Script cheat sheet](#cheat-sheet)
+* [Built With](#built-with)
+* [Deploying](#deploy)
+* [Linting](#linting)
+* [Contributing Rules](#rules)
+* [Common Questions](#faq)
+
+<a name="documentation"></a>
+## Further Documentation
+
+* **[System Roadmap]()**
+* **[Regression Testing Checklist]()**
+* **[Change Log]()**
+
+Include any other relevant documentation in this section.
+
+<a name="overview"></a>
+## System Overview
+
+* More in-depth overview of the system, what this is trying to accomplish and how it achieves its goal.
+* Keep it concise, write this section like the first paragraph of a blog post, what is the point of this repo?
+
+<a name="installation"></a>
+## Installation
+
+* Recordit of installation setup for new users
+* Step-by-step guide on installation
+
+<a name="running"></a>
+## Running Locally
+
+* Recordit of setting up the app for running locally
+* Step-by-step guide of setting up locally
+
+<a name="testing"></a>
+## Testing
+
+* What CI do the test run on?
+* What testing framework is used?
+
+<a name="cheat-sheet"></a>
+## Script Cheat Sheet
+
+* List scripts used in the repo and a description of what they do
+* Example: `npm run build` := Generates `dist` folder with changes made in `lib`
+
+<a name="testing"></a>
+## Testing
+
+<a name="automated"></a>
+### Automated Testing
+
+* Step-by-step to run unit/selenium tests
+
+<a name="manual"></a>
+### Manual Testing
+
+* Link to external regression checklist document
+
+<a name="built-with"></a>
+## Built With
+
+* What frameworks are used? Links to framework API docs.
+* Essential node modules used, links to documentation/repo.
+
+<a name="deploy"></a>
+## Deploying
+
+* How do deploys work for new pull requests?
+* What is the process from a feature branch to production?
+
+<!-- Optional on README but should be linked externally if not -->
+<a name="linting"></a>
+## Linting
+
+* How to I lint specific file types?
+* Do these run via git hooks
+* Link to linting rules
+
+<a name="rules"></a>
+## Contributing Rules
+
+* Link to HX-culture documentation on contribution
+* Any specific rules for this repo?
+
+<a name="faq"></a>
+## Common Questions
+
+* Frequently asked questions that will help engineers
+* Link to repo experts if not listed

--- a/readme-template.md
+++ b/readme-template.md
@@ -5,7 +5,7 @@
 
 <!--Short sentence on what the repo does-->
 
-##Contents
+## Contents
 * [Further Documentation](#further-documentation)
 * [System Overview](#system-overview)
 * [Installation](#installation)


### PR DESCRIPTION
This is a PR for the Front end guild objective for improving Readmes. I had a look through some of our repos, comparing them with each other and also looking at public repos from numerous organisations. Turns out most examples I saw were very poorly done and hard to follow for newbies to the project/team.

To address this, I have created a readme template that covers the common areas that a readme should cover. These will vary between repos but essential should be `How to run locally`, `Testing`, `Installation`, `Common Questions` and some system overview information, including frequently asked questions.

Let me know what you think, I am currently implementing this template to some of our front end repos so any feedback would be awesome. Cheers, Louis.  
