### PR TITLE
Updating submission preferences

### DIFF
--- a/recruitment/introduction.md
+++ b/recruitment/introduction.md
@@ -21,6 +21,6 @@ Alternatively if you regularly contribute to open-source and believe that we wil
 
 #### What to do after completing the task(s)?
 
-When you feel you've completed the task we would appreciate it if you could publish it online so we are in a position to be able to review it. We recommend that you upload your code to a Github/Bitbucket/Gitlab repository, however it's fine if you'd rather send it as an attachment in an email to your recruitment contact.
+When you feel you have completed the task, we would like you to host it and provide a link. We do not mind where it is hosted, as long as we can access your submission. We would also like you to publish your code to a Github/Bitbucket/Gitlab repository, so that we are in a position to review your work. Alternatively, you can earn bonus points by providing a Dockerfile.
 
 If you have any questions please do not hesitate to come back to us. We look forward to seeing the results of your efforts.


### PR DESCRIPTION
This PR updates the submission preferences for the developer test, based on a retro held last week, discussing our current implementation.

We now require a hosted submission and live link - this shows the ability to host projects
We have removed the option to provide an zip email attachment, preferring a published repo
We have also added the option to provide a Dockerfile 