### PR TITLE
Remove check boxes and change from the QA PR template

### DIFF
--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -1,12 +1,9 @@
-#### What are the links to original PRs?
+#### What is the link(s) to the original PR(s)?
+
 
 ---
-#### Quality checklist (for PR author to complete BEFORE peer review):
-- [ ] I've checked this work meets the requirements of the Jira.
-- [ ] I am ready for this to be merged to production for further testing and sign-off.
 
-#### @nameOfReviewer 
-- [ ] I agree with my work being merged to Production.
-- [ ] Clear of conflicts.
-- [ ] There have been no changes within this code that the QA has not been made aware of.
-- [ ] +1 from me!
+By approving this PR I agree that;
+- My work can be merged to Production.
+- Is clear of conflicts.
+- The QA has been made aware of all the changes in the code.

--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -4,7 +4,5 @@
 ---
 
 By approving this PR I agree that;
-- My work can be merged to Production.
-- Is clear of conflicts.
-- The QA has been made aware of all the changes in the code.
-- [ ] I confirm.
+- My work is ready to be merged to Production.
+- This PR contains **only** the changes in the original PR.

--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -7,4 +7,4 @@ By approving this PR I agree that;
 - My work can be merged to Production.
 - Is clear of conflicts.
 - The QA has been made aware of all the changes in the code.
--[]
+-[ ] I confirm.

--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -4,5 +4,5 @@
 ---
 
 By approving this PR I agree that;
-- My work is ready to be merged to Production.
-- This PR contains **only** the changes in the original PR.
+- I know what code changes are in this PR.
+- I am happy for the work in this PR to be merged to Master.

--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -7,4 +7,4 @@ By approving this PR I agree that;
 - My work can be merged to Production.
 - Is clear of conflicts.
 - The QA has been made aware of all the changes in the code.
--[ ] I confirm.
+- [ ] I confirm.

--- a/shortbreaks/pr-qa-template.md
+++ b/shortbreaks/pr-qa-template.md
@@ -1,4 +1,4 @@
-#### What is the link(s) to the original PR(s)?
+#### What is the link(s)to the original PR(s)?
 
 
 ---
@@ -7,3 +7,4 @@ By approving this PR I agree that;
 - My work can be merged to Production.
 - Is clear of conflicts.
 - The QA has been made aware of all the changes in the code.
+-[]


### PR DESCRIPTION
Hey QAs,

As discussed over various chats recently, we've no need to have all the tick boxes for the Devs on our QA PR template anymore. 

We also don't need to agree to say we've checked the work as a QA because obviously we would have before creating the PR for the dev to approve the merge to Master.

Lastly we now don't need to @ the developer. We can add them by using the 'reviewers' section on the right hand side. Simple click on the reviewer section and start typing the relevant person's name. This will notify them but I'd suggest still pinging the PR link over in a chat as well. 
![screen shot 2017-01-24 at 14 58 22](https://cloud.githubusercontent.com/assets/9378953/22252446/1aeba746-e246-11e6-96f5-09b6078dc9b3.png)

Let me know what you think.

Once happy I'll merge and this should automatically update your QA PR template bookmark.






