### PR TITLE
TPM guidance refinement

### DIFF
--- a/technical-planning-meeting.md
+++ b/technical-planning-meeting.md
@@ -33,18 +33,18 @@
 
 ## How does the process work?
 
-##### Part 1 - Before the TPM
+### Part 1 - Before the TPM
 
 * **Important update:** Prepare a solution to the problem. Try not to take an open or unconsidered problem case to the group, using it to refine and validate instead.
 * Make a copy of the [TPM template](https://docs.google.com/document/d/1cnVQXn5NuRiR7zMWDP4qXF9Qeqiwo2_glxFfEX5zjeM/edit) and fill out the top part. Announce the TPM in the Slack Channel #tpm, but make sure you consider and reach out to the people you think need to attend, as above.
 
-##### Part 2 - During the TPM
+### Part 2 - During the TPM
 
 * At the TPM, the host(s) explain the business problem they're trying to solve and open it up for discussion.
 * The host(s) explain their technical solution and opens it up for discussion.
 * Attendees challenge decisions and help to refine the solution, which is documented in the template copy shared on Slack.
 
-##### Part 3 - After the TPM
+### Part 3 - After the TPM
 
 * Following the TPM, the host(s) discuss the outcome with the Pod Lead and/ or key stakeholders to agree next steps and confirm business impact.
 * Once the TPM template has been completed in full it is shared again on the #tpm channel with a TL;DR of the decisions that were made.

--- a/technical-planning-meeting.md
+++ b/technical-planning-meeting.md
@@ -1,54 +1,50 @@
 
 # Technical Planning Meetings
 
-## Definition
+## What are they?
 
-* A technical planning meeting (TPM) is an informal discussion aimed at streamlining our development processes and agreeing on a technical solution and/ or next steps
-* They can be as short or as long as necessary
-* They should be requested by engineers
+* A technical planning meeting (TPM) is an informal discussion aimed at validating, refining and/or agreeing the technical solution to a given problem.
 
 ## When is one appropriate?
 
-* When starting a new project
-* When adding new features or functionality
-* When the technical implementation is not clear for the next iteration of a feature
-* When undertaking work that requires multiple teams to collaborate on a technical solution
+* When starting a new project.
+* When adding new features or functionality that are:
+ * Technically complex.
+ * Highly dependent on platforms/code.
+ * Changing or introducing a new fundamental piece.
+ * Likely to impact the work of other pods.
 
-## Expected Outcomes
+## What do you get from it?
 
-* High level documentation of the business problem, the technical solution and/ or next steps and the business impact (at a high level, it should be established how complex the task is in order that we can analyse the business impact)
-* Engineers should have a clear understanding of what is expected moving forward
-* What the next steps are, this could be a set of Jiras for Pod Leads to prioritise 
-* A definition of done/ acceptance criteria
-* Pod Leads or Stakeholders should be clear what [Tech Debt](https://github.com/holidayextras/culture/blob/master/tech-debt.md) there is with any MVP (Minimum Viable Product)
+* High level documentation of the business problem, the technical solution (or next steps to finding it) and the expected impact on platforms and pods.
+* Implementers should have a clear understanding of what is expected moving forward.
+* An understanding, shared with Pod Leads or Stakeholders, on what [Tech Debt](https://github.com/holidayextras/culture/blob/master/tech-debt.md) this work might create.
 
 
-## Probable Attendees
+## Who should be there?
 
-* Engineer(s) with a technical challenge
-* Engineer(s) to support the discussion and agree a technical solution/ next steps
-* Database gurus (if data engineer required. If so, ask in #pod-data for a rep)
-* UXUI gurus (if frontend work will be required. If so, ask in #pod-uxui for a rep)
-* Business owners (if the business requirements are sufficiently complex and to assess the business impact)
-* Testers (if there is a large testing requirement. If so, ask in #testers)
-* Project gurus (engineers might require additional technical assistance - if INF required, invite Damien Turner and if Multimedia required, invite Jess Everton)
+* In addition to the person/people presenting the technical challenge, it depends. You'll want to consider inviting:
+ * Platform experts in the areas you'll be affecting.
+ * Data representation if your solution calls for it.
+ * UX/UI experts if you're impacting the user Experience.
+ * Experts in the business problem if the business requirements are sufficiently complex.
+ * INF representation if you'll have any unique networking or hosting requirements.
+ * Multimedia representation where needed.
 
-## The Process
+## How does the process work?
 
 ##### Part 1 - Before the TPM
 
-* Make a copy of the [TPM template](https://docs.google.com/a/holidayextras.com/document/d/1zVbOz0dRAnzZ6UhjYO1Ce1YGI2dzvEoYvZfkTK7qjYU/edit?usp=sharing). Part 1 is completed and to increase visibility that the TPM is taking place, notification of the TPM is posted with a link to the document in the Slack Channel #tpm
+* **Important update:** Prepare a solution to the problem. Try not to take an open or unconsidered problem case to the group, using it to refine and validate instead.
+* Make a copy of the [TPM template](https://docs.google.com/document/d/1cnVQXn5NuRiR7zMWDP4qXF9Qeqiwo2_glxFfEX5zjeM/edit) and fill out the top part. Announce the TPM in the Slack Channel #tpm, but make sure you consider and reach out to the people you think need to attend, as above.
 
 ##### Part 2 - During the TPM
 
-* At the TPM, the engineer explains the business problem they're trying to solve and open it up for discussion (if there is no technical proposal, otherwise:)
-* The developers explain their technical solution and open it up for discussion
-* We exchange thoughts and ideas, fill in any blanks and compromise where necessary to reach a good solution - using the TPM template agenda as a meeting guide
-* We break the work down into small chunks
-* If the chunks of work are not small enough to begin work, arrange for future TPMs to dig deeper into the problem (an example of when this might be necessary - "We want to start selling Coach")
+* At the TPM, the host(s) explain the business problem they're trying to solve and open it up for discussion.
+* The host(s) explain their technical solution and opens it up for discussion.
+* Attendees challenge decisions and help to refine the solution, which is documented in the template copy shared on Slack.
 
 ##### Part 3 - After the TPM
 
-* Following the TPM, the engineer discusses the outcome with the Pod Lead and/ or key stakeholders to agree next steps and confirm business impact
-* Pod Leads prioritise the work as appropriate
-* Once the TPM template has been completed in full, circulate a link with the TL;DR section to relevant groups (e.g. webit email group)
+* Following the TPM, the host(s) discuss the outcome with the Pod Lead and/ or key stakeholders to agree next steps and confirm business impact.
+* Once the TPM template has been completed in full it is shared again on the #tpm channel with a TL;DR of the decisions that were made.

--- a/technical-planning-meeting.md
+++ b/technical-planning-meeting.md
@@ -9,10 +9,10 @@
 
 * When starting a new project.
 * When adding new features or functionality that are:
- * Technically complex.
- * Highly dependent on platforms/code.
- * Changing or introducing a new fundamental piece.
- * Likely to impact the work of other pods.
+  * Technically complex.
+  * Highly dependent on platforms/code.
+  * Changing or introducing a new fundamental piece.
+  * Likely to impact the work of other pods.
 
 ## What do you get from it?
 


### PR DESCRIPTION
Following a discussion between the directors and a few tech leads across the team, this is a refinement of the TPM guidance to put more responsibility on the hosts to provide solutions to ideas in advance to be refined and validated in the meeting. Also includes a link to a cut down, easier to circulate version of the meeting template, also for review.