### PR TITLE
Fixed invalid link and renamed it accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is a collection of documents that outline Holiday Extras' culture and devel
  * [Accessibility Best Practices](accessibility-best-practices.md)
  * [Application Tracking](application-tracking.md)
  * [Nightwatchjs Best Practices](nightwatchjs-best-practices.md)
- * [Testing Standard](testing-standard.md)
+ * [Testing Commandments](testing-commandments.md)
  * [Testing Overview](testing-overview.md)
  * [SEO Best Practices and Principles](seo/README.md)
  * [Frontend Performance](front-end-performance.md)


### PR DESCRIPTION
There is no file with the name `testing-standard.md` however, there is a file name `testing-commandments.md` which is not linked to and so I assumed that this was the original intention and fixed the link accordingly.